### PR TITLE
Fix Scheduler breaks on first run due to migration

### DIFF
--- a/.aspire/settings.json
+++ b/.aspire/settings.json
@@ -1,7 +1,3 @@
 {
-  "appHostPath": "../src/Aspire/BookWorm.AppHost/BookWorm.AppHost.csproj",
-  "features": {
-    "deployCommandEnabled": "true",
-    "execCommandEnabled": "true"
-  }
+  "appHostPath": "../src/Aspire/BookWorm.AppHost/BookWorm.AppHost.csproj"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "aspire",
+      "request": "launch",
+      "name": "Aspire: Launch Default AppHost",
+      "program": "${workspaceFolder}"
+    }
+  ]
+}

--- a/BookWorm.slnx
+++ b/BookWorm.slnx
@@ -45,8 +45,9 @@
     <Project Path="src/Services/Rating/BookWorm.Rating/BookWorm.Rating.csproj" />
   </Folder>
   <Folder Name="/Services/Scheduler/">
-    <Project Path="src/Services/Scheduler/BookWorm.Scheduler.UnitTests/BookWorm.Scheduler.UnitTests.csproj" />
     <Project Path="src/Services/Scheduler/BookWorm.Scheduler/BookWorm.Scheduler.csproj" />
+    <Project Path="src/Services/Scheduler/BookWorm.Scheduler.Migrator/BookWorm.Scheduler.Migrator.csproj" />
+    <Project Path="src/Services/Scheduler/BookWorm.Scheduler.UnitTests/BookWorm.Scheduler.UnitTests.csproj" />
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path="Directory.Build.props" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector" Version="$(ToolKitVersion)" />
     <PackageVersion Include="CommunityToolkit.Aspire.OllamaSharp" Version="$(ToolKitVersion)" />
     <!-- Extra -->
-    <PackageVersion Include="Scalar.Aspire" Version="0.5.1" />
+    <PackageVersion Include="Scalar.Aspire" Version="0.5.3" />
   </ItemGroup>
   <ItemGroup Label="Core Packages">
     <!-- Microsoft Extensions -->
@@ -102,7 +102,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="TngTech.ArchUnitNET.TUnit" Version="0.12.3" />
-    <PackageVersion Include="TUnit" Version="0.61.58" />
+    <PackageVersion Include="TUnit" Version="0.63.3" />
     <PackageVersion Include="Verify.TUnit" Version="30.19.2" />
     <!-- Microsoft Testing Platform -->
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.4" />

--- a/src/Aspire/BookWorm.AppHost/AppHost.cs
+++ b/src/Aspire/BookWorm.AppHost/AppHost.cs
@@ -259,16 +259,22 @@ var financeApi = builder
     .WithReference(queue)
     .WaitFor(queue);
 
+var schedulerMigrator = builder
+    .AddProject<SchedulerMigrator>(Services.SchedulerMigrator)
+    .WithReference(schedulerDb)
+    .WaitFor(schedulerDb);
+
 var schedulerApi = builder
     .AddProject<Scheduler>(Services.Scheduler)
-    .WithReference(schedulerDb)
-    .WaitFor(schedulerDb)
     .WithReference(queue)
     .WaitFor(queue)
+    .WithReference(schedulerDb)
+    .WaitForCompletion(schedulerMigrator)
     .WithEnvironment("TickerQBasicAuth__Username", schedulerUserName)
     .WithEnvironment("TickerQBasicAuth__Password", schedulerPassword);
 
 schedulerUserName.WithParentRelationship(schedulerApi);
+schedulerMigrator.WithParentRelationship(schedulerApi);
 
 var gateway = builder
     .AddApiGatewayProxy()

--- a/src/Aspire/BookWorm.AppHost/BookWorm.AppHost.csproj
+++ b/src/Aspire/BookWorm.AppHost/BookWorm.AppHost.csproj
@@ -60,6 +60,10 @@
       Include="..\..\Services\Scheduler\BookWorm.Scheduler\BookWorm.Scheduler.csproj"
       AspireProjectMetadataTypeName="Scheduler"
     />
+    <ProjectReference
+      Include="..\..\Services\Scheduler\BookWorm.Scheduler.Migrator\BookWorm.Scheduler.Migrator.csproj"
+      AspireProjectMetadataTypeName="SchedulerMigrator"
+    />
   </ItemGroup>
   <ItemGroup Label="Integrations">
     <ProjectReference

--- a/src/BuildingBlocks/BookWorm.Constants/Aspire/Services.cs
+++ b/src/BuildingBlocks/BookWorm.Constants/Aspire/Services.cs
@@ -11,6 +11,7 @@ public static class Services
     public static readonly string Chatting = nameof(Chatting).ToLowerInvariant();
     public static readonly string McpTools = nameof(McpTools).ToLowerInvariant();
     public static readonly string Scheduler = nameof(Scheduler).ToLowerInvariant();
+    public static readonly string SchedulerMigrator = nameof(SchedulerMigrator).ToLowerInvariant();
     public static readonly string Notification = nameof(Notification).ToLowerInvariant();
 
     public static string ToClientName(this string application, string? suffix = null)

--- a/src/Services/Scheduler/BookWorm.Scheduler.Migrator/BookWorm.Scheduler.Migrator.csproj
+++ b/src/Services/Scheduler/BookWorm.Scheduler.Migrator/BookWorm.Scheduler.Migrator.csproj
@@ -1,0 +1,5 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <ItemGroup>
+    <ProjectReference Include="..\BookWorm.Scheduler\BookWorm.Scheduler.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Services/Scheduler/BookWorm.Scheduler.Migrator/DataMigratorWorker.cs
+++ b/src/Services/Scheduler/BookWorm.Scheduler.Migrator/DataMigratorWorker.cs
@@ -1,0 +1,77 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using BookWorm.Scheduler.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace BookWorm.Scheduler.Migrator;
+
+[ExcludeFromCodeCoverage]
+public sealed class DataMigratorWorker(
+    IServiceProvider serviceProvider,
+    IHostEnvironment hostEnvironment,
+    IHostApplicationLifetime hostApplicationLifetime
+) : BackgroundService
+{
+    public const string ActivitySourceName = $"{nameof(Scheduler)}{nameof(Migrator)}";
+    private readonly ActivitySource _activitySource = new(ActivitySourceName);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var activity = _activitySource.StartActivity(
+            hostEnvironment.ApplicationName,
+            ActivityKind.Client
+        );
+
+        try
+        {
+            using var scope = serviceProvider.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<SchedulerDbContext>();
+
+            await EnsureDatabaseAsync(dbContext, stoppingToken);
+            await RunMigrationAsync(dbContext, stoppingToken);
+        }
+        catch (Exception ex)
+        {
+            activity?.AddException(ex);
+            throw;
+        }
+
+        hostApplicationLifetime.StopApplication();
+    }
+
+    private static async Task EnsureDatabaseAsync(
+        SchedulerDbContext dbContext,
+        CancellationToken stoppingToken
+    )
+    {
+        var dbCreator = dbContext.GetService<IRelationalDatabaseCreator>();
+
+        var strategy = dbContext.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            if (!await dbCreator.ExistsAsync(stoppingToken))
+            {
+                await dbCreator.CreateAsync(stoppingToken);
+            }
+        });
+    }
+
+    private static async Task RunMigrationAsync(
+        SchedulerDbContext dbContext,
+        CancellationToken stoppingToken
+    )
+    {
+        var strategy = dbContext.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+            await dbContext.Database.MigrateAsync(stoppingToken)
+        );
+    }
+
+    public override void Dispose()
+    {
+        _activitySource.Dispose();
+        base.Dispose();
+    }
+}

--- a/src/Services/Scheduler/BookWorm.Scheduler.Migrator/Program.cs
+++ b/src/Services/Scheduler/BookWorm.Scheduler.Migrator/Program.cs
@@ -1,0 +1,36 @@
+﻿using BookWorm.Constants.Aspire;
+using BookWorm.Scheduler.Infrastructure;
+using BookWorm.Scheduler.Migrator;
+using BookWorm.ServiceDefaults;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddServiceDefaults();
+
+builder.Services.AddHostedService<DataMigratorWorker>();
+
+builder
+    .Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing.AddSource(DataMigratorWorker.ActivitySourceName));
+
+builder.Services.AddDbContextPool<SchedulerDbContext>(options =>
+    options
+        .UseNpgsql(
+            builder.Configuration.GetConnectionString(Components.Database.Scheduler),
+            sqlOptions =>
+                sqlOptions.MigrationsAssembly(typeof(SchedulerDbContext).Assembly.FullName)
+        )
+        .UseSnakeCaseNamingConvention()
+        // Issue: https://github.com/dotnet/efcore/issues/35285
+        .ConfigureWarnings(warnings =>
+            warnings.Ignore(RelationalEventId.PendingModelChangesWarning)
+        )
+);
+
+builder.EnrichAzureNpgsqlDbContext<SchedulerDbContext>();
+
+var app = builder.Build();
+
+app.Run();

--- a/src/Services/Scheduler/BookWorm.Scheduler/Extensions/Extensions.cs
+++ b/src/Services/Scheduler/BookWorm.Scheduler/Extensions/Extensions.cs
@@ -12,8 +12,7 @@ internal static class Extensions
         // Add database configuration
         builder.AddAzurePostgresDbContext<SchedulerDbContext>(
             Components.Database.Scheduler,
-            _ => services.AddMigration<SchedulerDbContext>(),
-            true
+            excludeDefaultInterceptors: true
         );
 
         services.AddScoped<ISchedulerDbContext>(sp => sp.GetRequiredService<SchedulerDbContext>());
@@ -46,7 +45,6 @@ internal static class Extensions
             opt.SetMaxConcurrency(Environment.ProcessorCount);
             opt.SetInstanceIdentifier(Environment.MachineName);
             opt.UpdateMissedJobCheckDelay(TimeSpan.FromMinutes(5));
-            // Commenting out the first times to apply the migrations
             opt.AddOperationalStore<SchedulerDbContext>(efOpt =>
             {
                 efOpt.CancelMissedTickersOnAppStart();


### PR DESCRIPTION
# Pull Request Description

Fix Scheduler breaks on first run due to migration

## Checklist

- [x] My code follows the DDD principles
- [x] I've used the latest C# features and idioms
- [x] I've added/updated unit tests for business logic
- [x] Service boundaries are maintained (no cross-service direct dependencies)
- [x] Repository pattern is used for data access
- [x] Domain Events are used for cross-service communication
- [x] I've registered new services in AppHost project (if applicable)
- [x] I've updated both entities and DTOs (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Scheduler migrator that runs before the Scheduler to prepare the database and apply migrations.
  * Added a one-click IDE launch configuration to start the default AppHost.

* **Refactor**
  * Adjusted service startup ordering so the Scheduler waits for the migrator to complete.

* **Chores**
  * Bumped dependency versions for stability and testing.
  * Simplified configuration by removing unused deploy/exec feature flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->