### PR TITLE
Revistting Chat Service

### DIFF
--- a/src/BuildingBlocks/BookWorm.Chassis/AI/Extensions/A2AClientExtensions.cs
+++ b/src/BuildingBlocks/BookWorm.Chassis/AI/Extensions/A2AClientExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using BookWorm.Chassis.AI.Agents;
 using BookWorm.Chassis.Utilities;
-using BookWorm.Constants.Aspire;
 using Microsoft.Agents.AI;
 
 namespace BookWorm.Chassis.AI.Extensions;

--- a/src/BuildingBlocks/BookWorm.Chassis/AI/Middlewares/GuardrailMiddleware.cs
+++ b/src/BuildingBlocks/BookWorm.Chassis/AI/Middlewares/GuardrailMiddleware.cs
@@ -35,18 +35,14 @@ public static class GuardrailMiddleware
 
         return response;
 
-        static List<ChatMessage> FilterMessages(IEnumerable<ChatMessage> contents)
-        {
-            return [.. contents.Select(m => new ChatMessage(m.Role, FilterContent(m.Text)))];
-        }
+        static List<ChatMessage> FilterMessages(IEnumerable<ChatMessage> contents) =>
+            [.. contents.Select(m => new ChatMessage(m.Role, FilterContent(m.Text)))];
 
-        static string FilterContent(string content)
-        {
-            return _sourceArray.Any(keyword =>
+        static string FilterContent(string content) =>
+            _sourceArray.Any(keyword =>
                 content.Contains(keyword, StringComparison.OrdinalIgnoreCase)
             )
                 ? "[REDACTED: Forbidden content]"
                 : content;
-        }
     }
 }

--- a/src/BuildingBlocks/BookWorm.Chassis/AI/Middlewares/PIIMiddleware.cs
+++ b/src/BuildingBlocks/BookWorm.Chassis/AI/Middlewares/PIIMiddleware.cs
@@ -22,10 +22,8 @@ public static partial class PIIMiddleware
 
         return response;
 
-        static IList<ChatMessage> FilterMessages(IEnumerable<ChatMessage> messages)
-        {
-            return [.. messages.Select(m => new ChatMessage(m.Role, FilterPii(m.Text)))];
-        }
+        static IList<ChatMessage> FilterMessages(IEnumerable<ChatMessage> messages) =>
+            [.. messages.Select(m => new ChatMessage(m.Role, FilterPii(m.Text)))];
 
         static string FilterPii(string content)
         {

--- a/src/Services/Chat/BookWorm.Chat.UnitTests/Features/Create/CreateChatCommandTests.cs
+++ b/src/Services/Chat/BookWorm.Chat.UnitTests/Features/Create/CreateChatCommandTests.cs
@@ -2,7 +2,6 @@
 using BookWorm.Chat.Features;
 using BookWorm.Chat.Features.Create;
 using BookWorm.Chat.Infrastructure.ChatStreaming;
-using MediatR;
 
 namespace BookWorm.Chat.UnitTests.Features.Create;
 
@@ -28,7 +27,7 @@ public sealed class CreateChatCommandTests
         // Assert
         command.ShouldNotBeNull();
         command.ShouldBeOfType<CreateChatCommand>();
-        command.ShouldBeAssignableTo<ICommand>();
+        command.ShouldBeAssignableTo<ICommand<Guid>>();
         command.Prompt.ShouldBe(prompt);
     }
 
@@ -69,7 +68,7 @@ public sealed class CreateChatCommandTests
         // Act & Assert
         _handler.ShouldNotBeNull();
         _handler.ShouldBeOfType<UpdateChatHandler>();
-        _handler.ShouldBeAssignableTo<ICommandHandler<CreateChatCommand>>();
+        _handler.ShouldBeAssignableTo<ICommandHandler<CreateChatCommand, Guid>>();
     }
 
     [Test]
@@ -87,7 +86,8 @@ public sealed class CreateChatCommandTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.ShouldBe(Unit.Value);
+        result.ShouldBeOfType<Guid>();
+        result.ShouldNotBe(Guid.Empty);
         _chatStreamingMock.Verify(
             x => x.AddStreamingMessage(It.IsAny<Guid>(), prompt.Text),
             Times.Once
@@ -109,7 +109,8 @@ public sealed class CreateChatCommandTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.ShouldBe(Unit.Value);
+        result.ShouldBeOfType<Guid>();
+        result.ShouldNotBe(Guid.Empty);
         _chatStreamingMock.Verify(x => x.AddStreamingMessage(It.IsAny<Guid>(), ""), Times.Once);
     }
 
@@ -128,7 +129,8 @@ public sealed class CreateChatCommandTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.ShouldBe(Unit.Value);
+        result.ShouldBeOfType<Guid>();
+        result.ShouldNotBe(Guid.Empty);
         _chatStreamingMock.Verify(x => x.AddStreamingMessage(It.IsAny<Guid>(), "   "), Times.Once);
     }
 
@@ -149,7 +151,8 @@ public sealed class CreateChatCommandTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.ShouldBe(Unit.Value);
+        result.ShouldBeOfType<Guid>();
+        result.ShouldNotBe(Guid.Empty);
         _chatStreamingMock.Verify(
             x => x.AddStreamingMessage(It.IsAny<Guid>(), complexPrompt),
             Times.Once
@@ -172,7 +175,8 @@ public sealed class CreateChatCommandTests
         var result = await _handler.Handle(command, cancellationToken);
 
         // Assert
-        result.ShouldBe(Unit.Value);
+        result.ShouldBeOfType<Guid>();
+        result.ShouldNotBe(Guid.Empty);
         _chatStreamingMock.Verify(
             x => x.AddStreamingMessage(It.IsAny<Guid>(), prompt.Text),
             Times.Once
@@ -225,9 +229,12 @@ public sealed class CreateChatCommandTests
         var result3 = await _handler.Handle(command3, CancellationToken.None);
 
         // Assert
-        result1.ShouldBe(Unit.Value);
-        result2.ShouldBe(Unit.Value);
-        result3.ShouldBe(Unit.Value);
+        result1.ShouldBeOfType<Guid>();
+        result1.ShouldNotBe(Guid.Empty);
+        result2.ShouldBeOfType<Guid>();
+        result2.ShouldNotBe(Guid.Empty);
+        result3.ShouldBeOfType<Guid>();
+        result3.ShouldNotBe(Guid.Empty);
 
         _chatStreamingMock.Verify(
             x => x.AddStreamingMessage(It.IsAny<Guid>(), prompt1.Text),
@@ -260,9 +267,12 @@ public sealed class CreateChatCommandTests
         var result3 = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result1.ShouldBe(Unit.Value);
-        result2.ShouldBe(Unit.Value);
-        result3.ShouldBe(Unit.Value);
+        result1.ShouldBeOfType<Guid>();
+        result1.ShouldNotBe(Guid.Empty);
+        result2.ShouldBeOfType<Guid>();
+        result2.ShouldNotBe(Guid.Empty);
+        result3.ShouldBeOfType<Guid>();
+        result3.ShouldNotBe(Guid.Empty);
 
         _chatStreamingMock.Verify(
             x => x.AddStreamingMessage(It.IsAny<Guid>(), prompt.Text),
@@ -286,7 +296,8 @@ public sealed class CreateChatCommandTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.ShouldBe(Unit.Value);
+        result.ShouldBeOfType<Guid>();
+        result.ShouldNotBe(Guid.Empty);
         _chatStreamingMock.Verify(
             x => x.AddStreamingMessage(It.IsAny<Guid>(), specialPrompt),
             Times.Once
@@ -318,7 +329,8 @@ public sealed class CreateChatCommandTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        result.ShouldBe(Unit.Value);
+        result.ShouldBeOfType<Guid>();
+        result.ShouldNotBe(Guid.Empty);
         _chatStreamingMock.Verify(
             x => x.AddStreamingMessage(It.IsAny<Guid>(), multilinePrompt),
             Times.Once

--- a/src/Services/Chat/BookWorm.Chat.UnitTests/Features/Visualize/VisualizeWorkflowValidatorTests.cs
+++ b/src/Services/Chat/BookWorm.Chat.UnitTests/Features/Visualize/VisualizeWorkflowValidatorTests.cs
@@ -12,7 +12,7 @@ public sealed class VisualizeWorkflowValidatorTests
     public void GivenValidQueryWithMermaidType_WhenValidating_ThenShouldNotHaveValidationErrors()
     {
         // Arrange
-        var query = new VisualizeWorkflowQuery(VisualizationType.Mermaid);
+        var query = new VisualizeWorkflowQuery();
 
         // Act
         var result = _validator.TestValidate(query);
@@ -98,7 +98,7 @@ public sealed class VisualizeWorkflowValidatorTests
     public void GivenMinimumEnumValue_WhenValidating_ThenShouldNotHaveValidationError()
     {
         // Arrange
-        var query = new VisualizeWorkflowQuery((VisualizationType)0);
+        var query = new VisualizeWorkflowQuery();
 
         // Act
         var result = _validator.TestValidate(query);

--- a/src/Services/Chat/BookWorm.Chat/Features/Create/CreateChatCommand.cs
+++ b/src/Services/Chat/BookWorm.Chat/Features/Create/CreateChatCommand.cs
@@ -2,15 +2,17 @@
 
 namespace BookWorm.Chat.Features.Create;
 
-public sealed record CreateChatCommand(Prompt Prompt) : ICommand;
+public sealed record CreateChatCommand(Prompt Prompt) : ICommand<Guid>;
 
 public sealed class UpdateChatHandler(IChatStreaming chatStreaming)
-    : ICommandHandler<CreateChatCommand>
+    : ICommandHandler<CreateChatCommand, Guid>
 {
-    public async Task<Unit> Handle(CreateChatCommand request, CancellationToken cancellationToken)
+    public async Task<Guid> Handle(CreateChatCommand request, CancellationToken cancellationToken)
     {
-        await chatStreaming.AddStreamingMessage(Guid.CreateVersion7(), request.Prompt.Text);
+        var conversationId = Guid.CreateVersion7();
 
-        return Unit.Value;
+        await chatStreaming.AddStreamingMessage(conversationId, request.Prompt.Text);
+
+        return conversationId;
     }
 }

--- a/src/Services/Chat/BookWorm.Chat/Infrastructure/Backplane/Contracts/ICancellationManager.cs
+++ b/src/Services/Chat/BookWorm.Chat/Infrastructure/Backplane/Contracts/ICancellationManager.cs
@@ -2,6 +2,6 @@
 
 public interface ICancellationManager
 {
-    CancellationToken GetCancellationToken(Guid id);
-    Task CancelAsync(Guid id);
+    CancellationToken GetCancellationToken(Guid conversationId, Guid messageId);
+    Task CancelAsync(Guid conversationId);
 }

--- a/src/Services/Chat/BookWorm.Chat/Infrastructure/ChatHistory/VectorChatMessageStore.cs
+++ b/src/Services/Chat/BookWorm.Chat/Infrastructure/ChatHistory/VectorChatMessageStore.cs
@@ -8,8 +8,8 @@ namespace BookWorm.Chat.Infrastructure.ChatHistory;
 public sealed class VectorChatMessageStore : ChatMessageStore
 {
     private readonly AppSettings _appSettings;
-    private readonly VectorStoreCollection<Guid, ChatHistoryItem> _collection;
     private readonly ClaimsPrincipal _claimsPrincipal;
+    private readonly VectorStoreCollection<Guid, ChatHistoryItem> _collection;
 
     public VectorChatMessageStore(
         AppSettings appSettings,

--- a/src/Services/Chat/BookWorm.Chat/Infrastructure/ChatStreaming/ChatStreaming.cs
+++ b/src/Services/Chat/BookWorm.Chat/Infrastructure/ChatStreaming/ChatStreaming.cs
@@ -85,7 +85,10 @@ public sealed class ChatStreaming(
             assistantReplyId
         );
 
-        var token = backplaneService.CancellationManager.GetCancellationToken(assistantReplyId);
+        var token = backplaneService.CancellationManager.GetCancellationToken(
+            conversationId,
+            assistantReplyId
+        );
 
         // Publish user message fragment
         var userFragment = new ClientMessageFragment(
@@ -117,13 +120,8 @@ public sealed class ChatStreaming(
 
             await foreach (
                 var chunk in (
-                    (
-                        await orchestrationService.RunWorkflowStreamingAsync(
-                            text,
-                            tokenSource.Token
-                        )
-                    ).WithCancellation(tokenSource.Token)
-                )
+                    await orchestrationService.RunWorkflowStreamingAsync(text, tokenSource.Token)
+                ).WithCancellation(tokenSource.Token)
             )
             {
                 var finalFragment = new ClientMessageFragment(

--- a/src/Services/Chat/BookWorm.Chat/Program.cs
+++ b/src/Services/Chat/BookWorm.Chat/Program.cs
@@ -1,10 +1,6 @@
-using BookWorm.Chassis.AI.Extensions;
 using BookWorm.Chat.Extensions;
 using BookWorm.Chat.Infrastructure.AgentOrchestration.Agents;
 using BookWorm.ServiceDefaults;
-using Microsoft.Agents.AI;
-using Microsoft.Agents.AI.A2A;
-using Microsoft.Agents.AI.Hosting.A2A.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/Services/Rating/BookWorm.Rating.UnitTests/Features/Visualize/VisualizeWorkflowQueryTests.cs
+++ b/src/Services/Rating/BookWorm.Rating.UnitTests/Features/Visualize/VisualizeWorkflowQueryTests.cs
@@ -7,8 +7,8 @@ namespace BookWorm.Rating.UnitTests.Features.Visualize;
 
 public sealed class VisualizeWorkflowQueryTests
 {
-    private readonly Mock<ISummarizer> _summarizerMock = new();
     private readonly VisualizerWorkflowHandler _handler;
+    private readonly Mock<ISummarizer> _summarizerMock = new();
 
     public VisualizeWorkflowQueryTests()
     {

--- a/src/Services/Rating/BookWorm.Rating/Infrastructure/Summarizer/RatingSummarizer.cs
+++ b/src/Services/Rating/BookWorm.Rating/Infrastructure/Summarizer/RatingSummarizer.cs
@@ -45,7 +45,7 @@ public sealed class RatingSummarizer(
 
         var response = await workflowAgent.RunAsync(
             $"Summarize the following content: {content}",
-            thread: workflowAgentThread,
+            workflowAgentThread,
             cancellationToken: cancellationToken
         );
 


### PR DESCRIPTION
# Pull Request Description

This pull request updates the chat creation feature to return a `Guid` representing the new conversation instead of `Unit`, and modifies endpoint and handler interfaces accordingly. It also refactors related unit tests to expect and verify the returned `Guid` value. Additionally, it simplifies some filtering methods in AI middlewares using expression-bodied members.

**Chat Creation Feature Updates**

* The `CreateChatCommand` and its handler now return a `Guid` for the created conversation, replacing previous usage of `Unit`. All relevant assertions in `CreateChatCommandTests` have been updated to check for a non-empty `Guid` result instead of `Unit.Value`. [[1]](diffhunk://#diff-0ed6fd7d29c125d63248fa1a0ee16905a981059b8ee269e47d01ddb94a87a345L31-R30) [[2]](diffhunk://#diff-0ed6fd7d29c125d63248fa1a0ee16905a981059b8ee269e47d01ddb94a87a345L72-R71) [[3]](diffhunk://#diff-0ed6fd7d29c125d63248fa1a0ee16905a981059b8ee269e47d01ddb94a87a345L90-R90) [[4]](diffhunk://#diff-0ed6fd7d29c125d63248fa1a0ee16905a981059b8ee269e47d01ddb94a87a345L112-R113) [[5]](diffhunk://#diff-0ed6fd7d29c125d63248fa1a0ee16905a981059b8ee269e47d01ddb94a87a345L131-R133) [[6]](diffhunk://#diff-0ed6fd7d29c125d63248fa1a0ee16905a981059b8ee269e47d01ddb94a87a345L152-R155) [[7]](diffhunk://#diff-0ed6fd7d29c125d63248fa1a0ee16905a981059b8ee269e47d01ddb94a87a345L175-R179) [[8]](diffhunk://#diff-0ed6fd7d29c125d63248fa1a0ee16905a981059b8ee269e47d01ddb94a87a345L228-R237) [[9]](diffhunk://#diff-0ed6fd7d29c125d63248fa1a0ee16905a981059b8ee269e47d01ddb94a87a345L263-R275) [[10]](diffhunk://#diff-0ed6fd7d29c125d63248fa1a0ee16905a981059b8ee269e47d01ddb94a87a345L289-R300) [[11]](diffhunk://#diff-0ed6fd7d29c125d63248fa1a0ee16905a981059b8ee269e47d01ddb94a87a345L321-R333)
* The `CreateChatEndpoint` now returns a `Created<Guid>` result with the conversation ID, instead of `NoContent`. Endpoint tests have been updated to expect and verify the returned `Guid`, including cases for sequential and concurrent requests. [[1]](diffhunk://#diff-b08f726256e7ec686138278d6c136ecb5080b1afa4e8d1c535c62cbac75fdbbbR7-R34) [[2]](diffhunk://#diff-b08f726256e7ec686138278d6c136ecb5080b1afa4e8d1c535c62cbac75fdbbbR43-R59) [[3]](diffhunk://#diff-b08f726256e7ec686138278d6c136ecb5080b1afa4e8d1c535c62cbac75fdbbbL67-R143) [[4]](diffhunk://#diff-b08f726256e7ec686138278d6c136ecb5080b1afa4e8d1c535c62cbac75fdbbbR159-R184) [[5]](diffhunk://#diff-b08f726256e7ec686138278d6c136ecb5080b1afa4e8d1c535c62cbac75fdbbbR201-R221)
* The endpoint interface implementation has been updated to use `IEndpoint<Created<Guid>, CreateChatCommand, ISender, LinkGenerator>`.

**Code Simplification**

* Filtering methods in `GuardrailMiddleware` and `PIIMiddleware` have been refactored to use expression-bodied members for conciseness. [[1]](diffhunk://#diff-c388c6b7a765ab89ea6032608d98515275d6467908a66a82c1d42efbc5c715eeL38-L52) [[2]](diffhunk://#diff-e2c11ef881eea57b30123d74120ffaf8e0172c1067b97423ce75dfa4d6060001L25-R26)

**Minor Cleanup**

* Removed unused `using` directives in several files for clarity. [[1]](diffhunk://#diff-1a46610210c78d3c9d910b1a5ee80e4cab5c67dc679b695183a1da3e427478bcL3) [[2]](diffhunk://#diff-0ed6fd7d29c125d63248fa1a0ee16905a981059b8ee269e47d01ddb94a87a345L5)

These changes improve the clarity and correctness of the chat creation workflow, ensure proper return values, and make the codebase more concise and maintainable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Create Chat now uses POST and returns 201 Created with a conversation ID and Location header.
  - Command handling returns the created conversation ID for easier client correlation.

- Refactor
  - Cancellation handling is now scoped by conversation and message for more precise control.
  - Chat streaming updated to align with the new cancellation model.
  - Internal middleware simplified without changing behavior.

- Tests
  - Unit tests updated to validate Created responses and GUID-returning commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->