### PR TITLE
fix: JWT authentication by saving access token

### DIFF
--- a/src/BuildingBlocks/BookWorm.Chassis/Security/Extensions/AuthenticationExtensions.cs
+++ b/src/BuildingBlocks/BookWorm.Chassis/Security/Extensions/AuthenticationExtensions.cs
@@ -1,4 +1,6 @@
-﻿using BookWorm.Chassis.Security.Settings;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using BookWorm.Chassis.Security.Settings;
 using BookWorm.Chassis.Utilities;
 using BookWorm.Chassis.Utilities.Configurations;
 using BookWorm.Constants.Aspire;
@@ -62,13 +64,32 @@ public static class AuthenticationExtensions
                     realm,
                     options =>
                     {
-                        // Uses the Keycloak account client audience.
                         options.Audience = "account";
                         options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
                         options.TokenValidationParameters.ValidateAudience =
                             !builder.Environment.IsDevelopment();
                         options.TokenValidationParameters.ValidateIssuer =
                             !builder.Environment.IsDevelopment();
+
+                        options.SaveToken = true;
+                        options.Events = new()
+                        {
+                            OnTokenValidated = ctx =>
+                            {
+                                if (
+                                    ctx is
+                                    {
+                                        SecurityToken: JwtSecurityToken jwt,
+                                        Principal.Identity: ClaimsIdentity identity
+                                    }
+                                )
+                                {
+                                    identity.AddClaim(new("access_token", jwt.RawData));
+                                }
+
+                                return Task.CompletedTask;
+                            },
+                        };
                     }
                 );
 


### PR DESCRIPTION
## Proposed changes

This pull request updates the authentication extension in `AuthenticationExtensions.cs` to enhance JWT token handling and make token access easier for downstream consumers. The main change is the addition of logic to save the raw JWT access token as a claim after successful authentication.

**Authentication improvements:**

* Added `options.SaveToken = true` to persist the JWT token within the authentication context, enabling easier access to the token after authentication.
* Implemented an `OnTokenValidated` event handler that, upon successful token validation, adds the raw JWT token as an `access_token` claim to the authenticated user's identity. This allows downstream code to retrieve the original JWT token from the user's claims.
* Added necessary `using` directives for `System.IdentityModel.Tokens.Jwt` and `System.Security.Claims` to support the new token handling logic.

## Types of changes

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 💥 Breaking change
- [ ] 📝 Docs
- [ ] ♻️ Refactor

## Checklist

- [x] Code compiles correctly
- [x] All tests passing
- [x] Follows DDD principles
- [x] Service boundaries maintained
- [x] C# 14 & `.editorconfig` followed
